### PR TITLE
Minionize the build, CI touchups.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
+  - '6'
   - '5'
   - '4'
   - iojs-v3
@@ -18,13 +19,21 @@ before_install:
   - npm i -g npm@^2.0.0
 before_script:
   - npm prune
+after_script:
+  - echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
 after_success:
-  - npm run coverage
-  - npm run coverage:upload
   - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
   - python travis_after_all.py
   - 'export $(cat .to_export_back) &> /dev/null'
-  - npm run semantic-release
+  - |
+      if [ "$BUILD_LEADER" = "YES" -a "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
+        echo "Checking coverage and release status."
+        npm run coverage
+        npm run coverage:upload
+        npm run semantic-release
+      else
+        echo "I'm a minion, no coverage or semantic-releasing for me."
+      fi
 branches:
   except:
     - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
   - npm i -g npm@^2.0.0
 before_script:
   - npm prune
+script:
+  - npm run coverage
 after_script:
   - echo leader=$BUILD_LEADER status=$BUILD_AGGREGATE_STATUS
 after_success:
@@ -28,11 +30,11 @@ after_success:
   - |
       if [ "$BUILD_LEADER" = "YES" -a "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
         echo "Checking coverage and release status."
-        npm run coverage
+        npm install coveralls
         npm run coverage:upload
         npm run semantic-release
       else
-        echo "I'm a minion, no coverage or semantic-releasing for me."
+        echo "Either I'm a minion or the build failed. No coverage or semantic-releasing for me."
       fi
 branches:
   except:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.org/allenluce/node-autokey.svg?branch=master)](https://travis-ci.org/allenluce/node-autokey)
 [![Coverage Status](https://coveralls.io/repos/github/allenluce/node-autokey/badge.svg?branch=master)](https://coveralls.io/github/allenluce/node-autokey?branch=master)
 
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+
 A Javascript implementation of the simple
 [Autokey cipher](https://en.wikipedia.org/wiki/Autokey_cipher).
 Autokey has some useful characteristics: the output is the same length

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "chai": "3.5.0",
-    "coveralls": "^2.11.14",
     "cz-conventional-changelog": "^1.2.0",
     "istanbul": "^0.4.5",
     "mocha": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "chai": "3.5.0",
-    "coveralls": "^2.11.9",
-    "cz-conventional-changelog": "^1.1.6",
-    "istanbul": "^0.4.3",
-    "mocha": "3.1.0",
+    "coveralls": "^2.11.14",
+    "cz-conventional-changelog": "^1.2.0",
+    "istanbul": "^0.4.5",
+    "mocha": "3.1.2",
     "semantic-release": "^4.3.5"
   },
   "engines": {


### PR DESCRIPTION
Coveralls has been [spamming the last few Greenkeeper PR's](https://github.com/allenluce/node-autokey/pull/15#issuecomment-252829544) because each version of Node that Travis is building makes a call to Coveralls. Only the lead builder need do that.

This PR also includes Node 6 on the build list, update packages, and move the Coveralls module dependency into the build directly (as only the lead builder needs that).
